### PR TITLE
Use new pluginlib macro for declaring nodelets

### DIFF
--- a/pandar_driver/src/driver/nodelet.cc
+++ b/pandar_driver/src/driver/nodelet.cc
@@ -82,6 +82,5 @@ void DriverNodelet::devicePoll()
 
 // Register this plugin with pluginlib.  Names must match nodelet_pandar.xml.
 //
-// parameters are: package, class name, class type, base class type
-PLUGINLIB_DECLARE_CLASS(pandar_driver, DriverNodelet,
-						pandar_driver::DriverNodelet, nodelet::Nodelet);
+// parameters are: class type, base class type
+PLUGINLIB_EXPORT_CLASS(pandar_driver::DriverNodelet, nodelet::Nodelet);

--- a/pandar_pointcloud/src/conversions/cloud_nodelet.cc
+++ b/pandar_pointcloud/src/conversions/cloud_nodelet.cc
@@ -45,6 +45,5 @@ namespace pandar_pointcloud
 
 // Register this plugin with pluginlib.  Names must match nodelet_pandar.xml.
 //
-// parameters: package, class name, class type, base class type
-PLUGINLIB_DECLARE_CLASS(pandar_pointcloud, CloudNodelet,
-                        pandar_pointcloud::CloudNodelet, nodelet::Nodelet);
+// parameters: class type, base class type
+PLUGINLIB_EXPORT_CLASS(pandar_pointcloud::CloudNodelet, nodelet::Nodelet);

--- a/pandar_pointcloud/src/conversions/ringcolors_nodelet.cc
+++ b/pandar_pointcloud/src/conversions/ringcolors_nodelet.cc
@@ -46,6 +46,5 @@ namespace pandar_pointcloud
 
 // Register this plugin with pluginlib.  Names must match nodelet_pandar.xml.
 //
-// parameters: package, class name, class type, base class type
-PLUGINLIB_DECLARE_CLASS(pandar_pointcloud, RingColorsNodelet,
-                        pandar_pointcloud::RingColorsNodelet, nodelet::Nodelet);
+// parameters: class type, base class type
+PLUGINLIB_EXPORT_CLASS(pandar_pointcloud::RingColorsNodelet, nodelet::Nodelet);

--- a/pandar_pointcloud/src/conversions/transform_nodelet.cc
+++ b/pandar_pointcloud/src/conversions/transform_nodelet.cc
@@ -45,7 +45,6 @@ namespace pandar_pointcloud
 
 // Register this plugin with pluginlib.  Names must match nodelet_pandar.xml.
 //
-// parameters: package, class name, class type, base class type
-PLUGINLIB_DECLARE_CLASS(pandar_pointcloud, TransformNodelet,
-                        pandar_pointcloud::TransformNodelet,
+// parameters: class type, base class type
+PLUGINLIB_EXPORT_CLASS(pandar_pointcloud::TransformNodelet,
                         nodelet::Nodelet);


### PR DESCRIPTION
The PLUGINLIB_DECLARE_CLASS macro has been deprecated since ROS Groovy
and will be removed in ROS Melodic.  This updates the nodelets in this
package to use the replacement, PLUGINLIB_EXPORT_CLASS.