### PR TITLE
Make library names unique

### DIFF
--- a/pandar_pointcloud/nodelets.xml
+++ b/pandar_pointcloud/nodelets.xml
@@ -1,4 +1,4 @@
-<library path="lib/libcloud_nodelet">
+<library path="lib/libpandar_cloud_nodelet">
   <class name="pandar_pointcloud/CloudNodelet"
          type="pandar_pointcloud::CloudNodelet"
          base_class_type="nodelet::Nodelet">
@@ -8,7 +8,7 @@
   </class>
 </library>
 
-<library path="lib/libringcolors_nodelet">
+<library path="lib/libpandar_ringcolors_nodelet">
   <class name="pandar_pointcloud/RingColorsNodelet"
 		 type="pandar_pointcloud::RingColorsNodelet"
 		 base_class_type="nodelet::Nodelet">
@@ -19,7 +19,7 @@
   </class>
 </library>
 
-<library path="lib/libtransform_nodelet">
+<library path="lib/libpandar_transform_nodelet">
   <class name="pandar_pointcloud/TransformNodelet"
 		 type="pandar_pointcloud::TransformNodelet"
 		 base_class_type="nodelet::Nodelet">

--- a/pandar_pointcloud/src/conversions/CMakeLists.txt
+++ b/pandar_pointcloud/src/conversions/CMakeLists.txt
@@ -1,50 +1,42 @@
-add_executable(cloud_node cloud_node.cc convert.cc driver.cc)
-add_dependencies(cloud_node ${${PROJECT_NAME}_EXPORTED_TARGETS})
-target_link_libraries(cloud_node pandar_rawdata
+add_executable(pandar_cloud_node cloud_node.cc convert.cc driver.cc)
+add_dependencies(pandar_cloud_node ${${PROJECT_NAME}_EXPORTED_TARGETS})
+target_link_libraries(pandar_cloud_node pandar_rawdata
 					  pandar_input
 					  pcap
                       ${catkin_LIBRARIES} ${YAML_CPP_LIBRARIES})
-install(TARGETS cloud_node
-        RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 
-add_library(cloud_nodelet cloud_nodelet.cc convert.cc driver.cc)
-add_dependencies(cloud_nodelet ${${PROJECT_NAME}_EXPORTED_TARGETS})
-target_link_libraries(cloud_nodelet 
+add_library(pandar_cloud_nodelet cloud_nodelet.cc convert.cc driver.cc)
+add_dependencies(pandar_cloud_nodelet ${${PROJECT_NAME}_EXPORTED_TARGETS})
+target_link_libraries(pandar_cloud_nodelet 
 					  pandar_rawdata 
 					  pandar_input
 					  pcap
                       ${catkin_LIBRARIES} ${YAML_CPP_LIBRARIES})
-install(TARGETS cloud_nodelet
-        RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION}
-        ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-        LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})
 
-add_executable(ringcolors_node ringcolors_node.cc colors.cc)
-target_link_libraries(ringcolors_node
+add_executable(pandar_ringcolors_node ringcolors_node.cc colors.cc)
+target_link_libraries(pandar_ringcolors_node
 					  ${catkin_LIBRARIES} ${YAML_CPP_LIBRARIES})
-install(TARGETS ringcolors_node
-		RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 
-add_library(ringcolors_nodelet ringcolors_nodelet.cc colors.cc)
-target_link_libraries(ringcolors_nodelet
+add_library(pandar_ringcolors_nodelet ringcolors_nodelet.cc colors.cc)
+target_link_libraries(pandar_ringcolors_nodelet
 					  ${catkin_LIBRARIES} ${YAML_CPP_LIBRARIES})
-install(TARGETS ringcolors_nodelet
-		RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION}
-		ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-		LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})
 
-add_executable(transform_node transform_node.cc transform.cc)
-add_dependencies(transform_node ${${PROJECT_NAME}_EXPORTED_TARGETS})
-target_link_libraries(transform_node pandar_rawdata
+add_executable(pandar_transform_node transform_node.cc transform.cc)
+add_dependencies(pandar_transform_node ${${PROJECT_NAME}_EXPORTED_TARGETS})
+target_link_libraries(pandar_transform_node pandar_rawdata
 					  ${catkin_LIBRARIES} ${YAML_CPP_LIBRARIES})
-install(TARGETS transform_node
-		RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 
-add_library(transform_nodelet transform_nodelet.cc transform.cc)
-add_dependencies(transform_nodelet ${${PROJECT_NAME}_EXPORTED_TARGETS})
-target_link_libraries(transform_nodelet pandar_rawdata
+add_library(pandar_transform_nodelet transform_nodelet.cc transform.cc)
+add_dependencies(pandar_transform_nodelet ${${PROJECT_NAME}_EXPORTED_TARGETS})
+target_link_libraries(pandar_transform_nodelet pandar_rawdata
 					  ${catkin_LIBRARIES} ${YAML_CPP_LIBRARIES})
-install(TARGETS transform_nodelet
-		RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION}
+install(TARGETS 
+            pandar_cloud_node
+            pandar_cloud_nodelet
+            pandar_ringcolors_node
+            pandar_ringcolors_nodelet
+            pandar_transform_node
+            pandar_transform_nodelet
+		RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 		ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
 		LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})

--- a/pandar_pointcloud/src/lib/CMakeLists.txt
+++ b/pandar_pointcloud/src/lib/CMakeLists.txt
@@ -3,7 +3,7 @@ target_link_libraries(pandar_rawdata
                       ${catkin_LIBRARIES}
                       ${YAML_CPP_LIBRARIES})
 install(TARGETS pandar_rawdata
-        RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION}
+        RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
         ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
         LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})
 set_target_properties(pandar_rawdata PROPERTIES


### PR DESCRIPTION
Previously, the built library names were identical to the Velodyne driver
library names, and they were also installed in the global lib directory.
This means they would cause a conflict with the Velodyne binary packages
and it would be impossible to install both it and this package at the
same time.  This makes the library names unique, but the nodelet names
are still the same, so it should be backwards-compatible.